### PR TITLE
Error handling kafka

### DIFF
--- a/storm-kafka/project.clj
+++ b/storm-kafka/project.clj
@@ -1,4 +1,4 @@
-(defproject storm/storm-kafka_2.9.2 "0.8.2"
+(defproject storm/storm-kafka_2.9.2 "0.8.2.1"
   :source-path "src/clj"
   :java-source-path "src/jvm"
   :javac-options {:debug "true" :fork "true"}


### PR DESCRIPTION
added handling for IO Exceptions when talking to Kafka. Also changed the way that Kafka error codes are detected. IOExceptions are intentionally not handled in the constructor. Making the constructor exception safe might require more refactoring.
